### PR TITLE
Fixed play_sound categories to use values accepted in-game

### DIFF
--- a/schemas/apoli/types/playsound_category.json
+++ b/schemas/apoli/types/playsound_category.json
@@ -4,10 +4,10 @@
 		"music",
 		"record",
 		"weather",
-		"block",
+		"blocks",
 		"hostile",
 		"neutral",
-		"player",
+		"players",
 		"ambient",
 		"voice"
 	]


### PR DESCRIPTION
Quick fix for #16.
Changed "player" value into "players".
Changed "block" value into "blocks".